### PR TITLE
CI: Remove Report Job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,22 +84,3 @@ jobs:
           path: application/app/build/reports/androidTests/connected
         if: always()
         
-  # Job to generate the test report
-  report:
-    runs-on: ubuntu-latest
-    needs: test
-    
-    if: always()
-    steps:
-      - name: Download Unit Test Results
-        uses: actions/download-artifact@v2
-        with:
-          name: unit-test-results
-          
-      - name: Download Instrumented Test Results
-        uses: actions/download-artifact@v2
-        with:
-          name: instrumented-test-results
-
-      - name: Generate Test Report
-        uses: asadmansr/android-test-report-action@v1.2.0


### PR DESCRIPTION
Did some experimenting with caching on my cloned repo and didn't notice any significant improvements in run time. This PR is removing the report job, because the previous "test" job already generates reports.