### PR TITLE
Update CI Gradle Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-version: 7.0.2
           arguments: build
           build-root-directory: application
     
@@ -61,6 +62,7 @@ jobs:
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-version: 7.0.2
           arguments: testDebugUnitTest
           build-root-directory: application
         


### PR DESCRIPTION
The CI automatically builds/tests our apps using Gradle 7.3.3.  Gradle needs to be <=7.2 in order to be compatible with Chaquopy. I set the Gradle version to 7.0.2, which is the version we are currently using in our app.