### PR TITLE
CI Fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Set up Gradle
         run: chmod +x ./application/gradlew 
         
+      - name: Touch local properties
+        run: touch local.properties
+  
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -58,6 +61,9 @@ jobs:
       # Need to make sure gradlew is executable
       - name: Set up Gradle
         run: chmod +x ./application/gradlew 
+      
+      - name: Touch local properties 
+        run: touch local.properties
         
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: chmod +x ./application/gradlew 
         
       - name: Touch local properties
-        run: touch local.properties
+        run: touch application/local.properties
   
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
@@ -63,7 +63,7 @@ jobs:
         run: chmod +x ./application/gradlew 
       
       - name: Touch local properties 
-        run: touch local.properties
+        run: touch applicaiton/local.properties
         
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         run: chmod +x ./application/gradlew 
       
       - name: Touch local properties 
-        run: touch applicaiton/local.properties
+        run: touch application/local.properties
         
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+## Local Properties files should not be checked into git, but the CI needs one to run properly, hence this empty file.

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,0 @@
-## Local Properties files should not be checked into git, but the CI needs one to run properly, hence this empty file.


### PR DESCRIPTION
The CI wasn't running because our repo doesn't contain a local.properties file. The local.properties file should not be checked into git, and should only exist on each of our local computers. So to fix the issue, we temporarily create one in each CI job.